### PR TITLE
Feature/re install instructions

### DIFF
--- a/demo/kc_realm_export.json
+++ b/demo/kc_realm_export.json
@@ -500,7 +500,7 @@
       "id" : "24449f8e-cb4a-47d0-be42-43f0dc8f0f73",
       "type" : "password",
       "createdDate" : 1612556446213,
-      "secretData" : "{\"value\":\"R+juG1x1JJmUPXZMJQGQ2cYFn+pD4IS9qsVRqzDjfFuKGs2XX5PEUNM5H7GYCJmHdi4CK69HKBMGlDWcqCKswg==\",\"salt\":\"GALUISM7zzvRZOZsl48lBA==\"}",
+      "secretData" : "{\"value\":\"CwvQRbm9zgUa0OA6v+L8uEdd/jK7iJNq6kZApvTAcUpOOVaLtTVoAuvc9VzR/7p6lcdts82DNlzHINitpRcA2A==\",\"salt\":\"YkITGCVovcQgZvOlfPXdpw==\",\"additionalParameters\":{}}",
       "credentialData" : "{\"hashIterations\":27500,\"algorithm\":\"pbkdf2-sha256\",\"additionalParameters\":{}}"
     } ],
     "disableableCredentialTypes" : [ ],

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -132,7 +132,7 @@ services:
     environment:
       IPR_DATABASE_HOSTNAME: ipr_db
       IPR_DATABASE_NAME: ipr_demo
-      IPR_DATABASE_USERNAME: ipr_ro
+      IPR_DATABASE_USERNAME: ipr_service
       IPR_GRAPHKB_USERNAME: ipr_graphkb_link
       IPR_KEYCLOAK_KEYFILE: /keys/keycloak.key
       # customize settings below

--- a/docs/install.md
+++ b/docs/install.md
@@ -5,6 +5,10 @@ Since PORI is a production-ready, institution-level, scalable platform, the simp
 
 Most of the servers are auto-started together with docker-compose but the keycloak container must be started and configured on its own first.
 
+!!! Note
+
+    If this is not your first time setting up or running these instructions see the [update instructions](#updating-an-existing-demo-install) instead
+
 Start by cloning this repository which contains the default docker compose configs (`docker-compose.yml` and `docker-compose.dev.yml`)
 
 ```bash
@@ -49,7 +53,7 @@ mkdir keys
 Next, use docker-compose to start the DB, API, and client servers. The paths/URLs in the docker-compose.yml file should be adjusted to match your deployment. In our demo deployment we have a proxy pass set up from the configured ports to handle the https layer
 
 ```bash
-docker-compose -f docker-compose.dev.yml up -d
+docker-compose -f docker-compose.dev.yml up -d --build --remove-orphans
 ```
 
 This will start the following services
@@ -58,6 +62,7 @@ This will start the following services
 - OrientDB server for GraphKB with an empty default db
 - GraphKB API server (nodejs)
 - IPR API server (nodejs)
+- IPR API migration task (nodejs)
 - GraphKB client server (nginx)
 - IPR client server (nginx)
 - Keycloak Authentication server
@@ -112,6 +117,29 @@ docker run --net host \
     Because we are running the loader by itself we need to provide the mount arguments to tell docker that we need access to a file outside of the container itself. When we run this with the snakemake pipeline this is not necessary since snakemake generally takes care of that for you
 
 Once you have tested that things have been set up correctly and loading is working you are ready to initialize the data in your newly create GraphKB instance. See the [loader documentation](./graphkb/loading_data.md) for further instructions.
+
+## Updating an Existing Demo Install
+
+If you have previously installed, or partially installed this demo before you should make sure to remove all the previous containers and the database and keys folder prior to re-running the above instructions
+
+For example, to grep and remove all pori-related containers (This is dangerous if you have other docker containers running here that may be caught by grep. In that case you should remove them individually instead)
+
+```bash
+for x in $(docker ps -a | grep pori | cut -f 1 -d' '); do docker stop $x; docker rm $x; done
+```
+
+Next remove the databases and keys folders
+
+```bash
+rm -rf databases keys
+```
+
+Now you are ready to pull the lastest version of master and re-run the install instructions from the top
+
+```bash
+git checkout master
+git pull
+```
 
 ## Production Instances
 


### PR DESCRIPTION
Improvements
- Adds some instructions on setting up demo if you've already tried to set it up before
- Default to using the write-access ipr_service user for IPR API since most users will want to test loading reports after setting up the demo

BugFixes
- Change the password value for the iprdemo user to match the other demo/default users 